### PR TITLE
Fix rbac permission issue on 3.6eus

### DIFF
--- a/deploy/olm-catalog/ibm-monitoring-exporters-operator/1.9.6/ibm-monitoring-exporters-operator.v1.9.6.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-monitoring-exporters-operator/1.9.6/ibm-monitoring-exporters-operator.v1.9.6.clusterserviceversion.yaml
@@ -164,15 +164,26 @@ spec:
                 - events
                 - secrets
               verbs:
-                - "*"
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - delete
             - apiGroups:
                 - apps
               resources:
                 - deployments
                 - daemonsets
                 - replicasets
+                - deployments/finalizers
               verbs:
-                - "*"
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - delete
             - apiGroups:
                 - monitoring.coreos.com
               resources:
@@ -187,19 +198,20 @@ spec:
                 - exporters/finalizers
                 - exporters/status
               verbs:
-                - "*"
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - delete
             - apiGroups:
                 - certmanager.k8s.io
               resources:
                 - certificates
               verbs:
-                - "*"
-            - apiGroups:
-                - certmanager.k8s.io
-              resources:
-                - issuers
-              verbs:
-                - use
+              - get
+              - list
+              - watch
           serviceAccountName: ibm-monitoring-exporters-operator
       clusterPermissions:
         - rules:

--- a/deploy/olm-catalog/ibm-monitoring-exporters-operator/1.9.6/ibm-monitoring-exporters-operator.v1.9.6.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-monitoring-exporters-operator/1.9.6/ibm-monitoring-exporters-operator.v1.9.6.clusterserviceversion.yaml
@@ -212,6 +212,9 @@ spec:
               - get
               - list
               - watch
+              - create
+              - update
+              - delete
           serviceAccountName: ibm-monitoring-exporters-operator
       clusterPermissions:
         - rules:

--- a/deploy/olm-catalog/ibm-monitoring-exporters-operator/1.9.6/ibm-monitoring-exporters-operator.v1.9.6.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-monitoring-exporters-operator/1.9.6/ibm-monitoring-exporters-operator.v1.9.6.clusterserviceversion.yaml
@@ -164,12 +164,12 @@ spec:
                 - events
                 - secrets
               verbs:
-              - get
-              - list
-              - watch
-              - create
-              - update
-              - delete
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - apps
               resources:
@@ -178,12 +178,12 @@ spec:
                 - replicasets
                 - deployments/finalizers
               verbs:
-              - get
-              - list
-              - watch
-              - create
-              - update
-              - delete
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - monitoring.coreos.com
               resources:
@@ -198,23 +198,23 @@ spec:
                 - exporters/finalizers
                 - exporters/status
               verbs:
-              - get
-              - list
-              - watch
-              - create
-              - update
-              - delete
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
             - apiGroups:
                 - certmanager.k8s.io
               resources:
                 - certificates
               verbs:
-              - get
-              - list
-              - watch
-              - create
-              - update
-              - delete
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
           serviceAccountName: ibm-monitoring-exporters-operator
       clusterPermissions:
         - rules:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -151,3 +151,6 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
+  - deleteßßß

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -153,4 +153,4 @@ rules:
   - watch
   - create
   - update
-  - deleteßßß
+  - delete

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -103,15 +103,26 @@ rules:
   - events
   - secrets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - apps
   resources:
   - deployments
   - daemonsets
   - replicasets
+  - deployments/finalizers
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -126,16 +137,17 @@ rules:
   - exporters/finalizers
   - exporters/status
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 - apiGroups:
   - certmanager.k8s.io
   resources:
   - certificates
   verbs:
-  - '*'
-- apiGroups:
-  - certmanager.k8s.io
-  resources:
-  - issuers
-  verbs:
-  - use
+  - get
+  - list
+  - watch


### PR DESCRIPTION
In order to reduce the namespace-scope operator permissions, we need the operator and operands have enumerated the required verbs. Hence part of fix , we are removing the wildchar (*) verb and specified the required verbs in the CSV as well as in the role file.

Issue https://github.ibm.com/IBMPrivateCloud/roadmap/issues/45003